### PR TITLE
Fixes callback error

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(options) {
         }
 
         var contents = file.contents.toString();
-        svgtojsx(contents, options).then(function(result) {
+        svgtojsx(contents, options, undefined).then(function(result) {
             var output = new gutil.File({
                 contents: new Buffer(result),
                 path: file.path


### PR DESCRIPTION
Fixes the callback error caused by supplying only 2 arguments to `svg-to-jsx` package.
The issue is described here (#1).

![image](https://user-images.githubusercontent.com/4458855/34448498-c7f1abae-eca2-11e7-8a89-14233e8d5b1d.png)
